### PR TITLE
Default opts parameter to empty object if ommited preventing TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const IMAGE_WEIGHT = {
 class LastFM {
   constructor (key, opts) {
     if (!key) throw new Error('Missing required `key` argument')
+    opts = opts || {}
     this._key = key
     this._userAgent = opts.userAgent || 'last-fm (https://github.com/feross/last-fm)'
     this._minArtistListeners = opts.minArtistListeners || 0


### PR DESCRIPTION
I got a type error (see below) when i omitted the opts parameter. This PR will fix the error by defaulting opts to en empty object if it's undefined. 

```
this._userAgent = opts.userAgent || 'last-fm (https://github.com/feross/last-fm)'
                          ^
TypeError: Cannot read property 'userAgent' of undefined
```