### PR TITLE
Fix _parseTags() causing error when songs are missing tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ class LastFM {
   }
 
   _parseTags (tags) {
-    return tags.tag.map(t => t.name)
+    return tags && tags.tag ? tags.tag.map(t => t.name) : []
   }
 
   _parseTracks (tracks) {

--- a/index.js
+++ b/index.js
@@ -116,7 +116,13 @@ class LastFM {
   }
 
   _parseTags (tags) {
-    return tags && tags.tag ? tags.tag.map(t => t.name) : []
+    if (!tags) {
+      return [];
+    } else if (tags instanceof Array) {
+      return tags.tag.map(t => t.name)
+    } else {
+      return [tags.tag.name];
+    }
   }
 
   _parseTracks (tracks) {

--- a/index.js
+++ b/index.js
@@ -116,9 +116,9 @@ class LastFM {
   }
 
   _parseTags (tags) {
-    if (!tags) {
+    if (!tags || !tags.tag) {
       return [];
-    } else if (tags instanceof Array) {
+    } else if (tags.tag instanceof Array) {
       return tags.tag.map(t => t.name)
     } else {
       return [tags.tag.name];


### PR DESCRIPTION
Really simply fix, just making `_parseTags()` return an empty list when track.toptags or track.toptags.tag are missing

Edit: okay the issue i was experiencing was actually because tags.tag can sometimes be an object instead of an array of objects:
![image](https://user-images.githubusercontent.com/10006314/127719289-89113da0-291a-4783-9429-3bb2a16368e4.png)

So now I've fixed _parseTags so that it can handle that